### PR TITLE
setState() worked to stop the problem here

### DIFF
--- a/lib/drawing_page.dart
+++ b/lib/drawing_page.dart
@@ -181,7 +181,10 @@ class _DrawingPageState extends State<DrawingPage> {
       line = DrawnLine(line.path, selectedColor, selectedShape, selectedWidth);
       lines = List.from(lines)..add(line);
       if (conflictTest(lines) == false) {
-        lines = List.from(lines)..removeLast();
+        setState(() {
+          lines.removeLast();
+          line = null;
+        });
       } else {
         linesStreamController.add(lines);
       }


### PR DESCRIPTION
The problem has been fixed now so the conflict test actually does stop the lines from being added to the drawnLines list and sent to the sketcher.